### PR TITLE
move to the next screen on enter when writing room or player name

### DIFF
--- a/src/components/InputName.tsx
+++ b/src/components/InputName.tsx
@@ -35,6 +35,9 @@ export const InputName: FunctionComponent<Props> = ({
           inputClassName="text-center text-xl font-bold placeholder:font-normal"
           value={value}
           onChange={onChange}
+          onClick={() => join(value, false)}
+          hideButton
+          canContinue={!disabled}
         />
       </div>
       <div className="flex flex-row my-4 items-center justify-center">

--- a/src/components/InputWithButton.tsx
+++ b/src/components/InputWithButton.tsx
@@ -1,5 +1,7 @@
 import clsx from "clsx";
 import { FunctionComponent } from "preact";
+import { JSXInternal } from "preact/src/jsx";
+import { useCallback } from "preact/hooks";
 import { ReactComponent as NextButton } from "../assets/arrow-right.svg";
 
 interface Props {
@@ -9,6 +11,7 @@ interface Props {
   value?: string;
   onChange(s: string): void;
   hideLabel?: boolean;
+  hideButton?: boolean;
   containerClassName?: string;
   inputClassName?: string;
   onClick?: () => void;
@@ -37,42 +40,53 @@ export const InputWithButton: FunctionComponent<Props> = ({
   containerClassName,
   inputClassName,
   hideLabel = false,
+  hideButton = false,
   onClick,
   canContinue,
-}) => (
-    <div
-      className={containerClassName}
-    >
-      <label
-        htmlFor={id}
-        className={clsx("text-sm font-medium text-gray-900", hideLabel && "hidden")}
-      >
-        { label }
-      </label>
-      <div
-        className={style}
-      >
-        <input
-          autoCapitalize="on"
-          className={clsx(inputClassName, "outline-none")}
-          id={id}
-          type="text"
-          value={value}
-          placeholder={placeholder}
-          onInput={(e) => onChange((e.target as HTMLInputElement).value)}
-        />
-        { onClick && (
+}) => {
+  const onSubmit: JSXInternal.GenericEventHandler<HTMLFormElement> = useCallback((e) => {
+    e.preventDefault();
+    if (onClick && canContinue) {
+      onClick();
+    }
+  }, [ onClick, canContinue ]);
 
-        <button
-          disabled={!canContinue}
-          className={clsx(buttonStyle, canContinue ? "text-black" : "text-gray-400")}
-          onClick={onClick}
+  return (
+      <form
+          className={containerClassName}
+          onSubmit={onSubmit}
+      >
+        <label
+            htmlFor={id}
+            className={clsx("text-sm font-medium text-gray-900", hideLabel && "hidden")}
         >
-          <NextButton
-            className="w-6 h-6"
+          {label}
+        </label>
+        <div
+            className={style}
+        >
+          <input
+              autoCapitalize="on"
+              className={clsx(inputClassName, "outline-none")}
+              id={id}
+              type="text"
+              value={value}
+              placeholder={placeholder}
+              onInput={(e) => onChange((e.target as HTMLInputElement).value)}
           />
-        </button>
-        )}
-      </div>
-    </div>
-);
+          {onClick && (
+
+              <button
+                  type="submit"
+                  disabled={!canContinue}
+                  className={clsx(buttonStyle, canContinue ? "text-black" : "text-gray-400", hideButton && "hidden")}
+              >
+                <NextButton
+                    className="w-6 h-6"
+                />
+              </button>
+          )}
+        </div>
+      </form>
+  );
+};


### PR DESCRIPTION
Treat InputWithButton as a form so that onClick is called on submit. That means pressing enter will now move you to the next screen.

InputName was modified so that the user joins as a player when enter is pressed (not as an observer). I briefly considered having them join as what they joined as last time, but that would probably be confusing due to its inconsistency.